### PR TITLE
Platform Specific Build Split in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,25 +91,36 @@ jobs:
       - run: cargo audit --file cli/Cargo.lock
 
   # ── Build, Clippy & Test ──────────────────────────────
-  build:
-    name: "Build: ${{ matrix.os_name }}"
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: ubuntu-latest
-            os_name: Linux
-            artifact: dotfiles-linux
-            binary_name: dotfiles
-          - runner: windows-latest
-            os_name: Windows
-            artifact: dotfiles-windows
-            binary_name: dotfiles.exe
+  build-linux:
+    name: "Build: Linux"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "cli -> target"
+          cache-on-failure: true
+      - name: Build CI binary
+        run: cargo build --profile ci --manifest-path cli/Cargo.toml
+      - name: Clippy
+        run: cargo clippy --profile ci --manifest-path cli/Cargo.toml --all-targets -- -D warnings
+      - name: Tests
+        run: cargo test --profile ci --manifest-path cli/Cargo.toml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dotfiles-linux
+          path: cli/target/ci/dotfiles
+          retention-days: 1
+
+  build-windows:
+    name: "Build: Windows"
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
       - name: Disable Windows Defender real-time monitoring
-        if: runner.os == 'Windows'
         run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -126,59 +137,57 @@ jobs:
         run: cargo test --profile ci --manifest-path cli/Cargo.toml
       - uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
-          path: cli/target/ci/${{ matrix.binary_name }}
+          name: dotfiles-windows
+          path: cli/target/ci/dotfiles.exe
           retention-days: 1
 
   # ── Integration Tests ─────────────────────────────────
-  integration:
-    name: "Integration: ${{ matrix.profile }} on ${{ matrix.os_name }}"
-    runs-on: ${{ matrix.runner }}
-    needs: [build]
+  integration-linux:
+    name: "Integration: ${{ matrix.profile }} on Linux"
+    runs-on: ubuntu-latest
+    needs: [build-linux]
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - runner: ubuntu-latest
-            os_name: Linux
-            artifact: dotfiles-linux
-            binary_name: dotfiles
-            profile: base
-          - runner: ubuntu-latest
-            os_name: Linux
-            artifact: dotfiles-linux
-            binary_name: dotfiles
-            profile: desktop
-          - runner: windows-latest
-            os_name: Windows
-            artifact: dotfiles-windows
-            binary_name: dotfiles.exe
-            profile: base
-          - runner: windows-latest
-            os_name: Windows
-            artifact: dotfiles-windows
-            binary_name: dotfiles.exe
-            profile: desktop
+        profile: [base, desktop]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.artifact }}
+          name: dotfiles-linux
           path: bin/
       - name: Make binary executable
-        if: runner.os == 'Linux'
-        run: chmod +x bin/${{ matrix.binary_name }}
+        run: chmod +x bin/dotfiles
+      - name: Dry-run install
+        run: ./bin/dotfiles --root . -p ${{ matrix.profile }} -d install
+      - name: Run validation
+        run: ./bin/dotfiles --root . -p ${{ matrix.profile }} test
+
+  integration-windows:
+    name: "Integration: ${{ matrix.profile }} on Windows"
+    runs-on: windows-latest
+    needs: [build-windows]
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [base, desktop]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dotfiles-windows
+          path: bin/
       - name: Dry-run install
         shell: bash
-        run: ./bin/${{ matrix.binary_name }} --root . -p ${{ matrix.profile }} -d install
+        run: ./bin/dotfiles.exe --root . -p ${{ matrix.profile }} -d install
       - name: Run validation
         shell: bash
-        run: ./bin/${{ matrix.binary_name }} --root . -p ${{ matrix.profile }} test
+        run: ./bin/dotfiles.exe --root . -p ${{ matrix.profile }} test
 
   test-install-uninstall:
     name: "Integration: Install/Uninstall round-trip"
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-linux]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -195,7 +204,7 @@ jobs:
   test-install-uninstall-windows:
     name: "Integration: Install/Uninstall round-trip (Windows)"
     runs-on: windows-latest
-    needs: [build]
+    needs: [build-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -213,7 +222,7 @@ jobs:
   test-applications:
     name: "App: ${{ matrix.application }}"
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-linux]
     strategy:
       fail-fast: false
       matrix:
@@ -265,7 +274,7 @@ jobs:
   test-shell-wrapper-linux:
     name: "Shell Wrapper: Linux (dotfiles.sh)"
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build-linux]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -282,7 +291,7 @@ jobs:
   test-shell-wrapper-windows:
     name: "Shell Wrapper: Windows (dotfiles.ps1)"
     runs-on: windows-latest
-    needs: [build]
+    needs: [build-windows]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -305,8 +314,10 @@ jobs:
       - lint
       - validate-config
       - audit
-      - build
-      - integration
+      - build-linux
+      - build-windows
+      - integration-linux
+      - integration-windows
       - test-install-uninstall
       - test-install-uninstall-windows
       - test-applications


### PR DESCRIPTION
Split the matrix build job into build-linux and build-windows, and similarly
  split integration into integration-linux and integration-windows. Each downstream job
  now depends only on its platform's build — Linux tests won't wait for the Windows
  build and vice versa.