### PR TITLE
fix(logging): improve observability and logging coverage

### DIFF
--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -42,7 +42,7 @@ pub fn run(
     if std::env::var_os(super::REEXEC_GUARD_VAR).is_none()
         && phases::bootstrap::self_update::pre_update(&root, &**log, global.dry_run)?
     {
-        super::re_exec(&root);
+        super::re_exec(&root, &**log);
     }
 
     let runner = super::CommandRunner::new(global, log, token)?;

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -29,12 +29,8 @@ const WINDOWS_RESTART_EXIT_CODE: i32 = 75;
 /// Called after a self-update has replaced the binary on disk so that the
 /// new version runs all tasks with updated code.  Sets [`REEXEC_GUARD_VAR`]
 /// so the new process skips the self-update step.
-#[allow(
-    unused_variables,
-    clippy::print_stderr,
-    reason = "intentional user-facing output"
-)]
-pub(crate) fn re_exec(root: &std::path::Path) -> ! {
+#[allow(unused_variables, reason = "root is platform-specific re-exec context")]
+pub(crate) fn re_exec(root: &std::path::Path, log: &dyn Output) -> ! {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -44,14 +40,14 @@ pub(crate) fn re_exec(root: &std::path::Path) -> ! {
             .args(&args)
             .env(REEXEC_GUARD_VAR, "1")
             .exec();
-        eprintln!("\x1b[31mError: failed to re-exec: {err}\x1b[0m");
+        log.error(&format!("failed to re-exec: {err}"));
         std::process::exit(1);
     }
 
     #[cfg(windows)]
     {
         if let Err(err) = spawn_windows_restart_helper() {
-            eprintln!("\x1b[31mError: failed to schedule Windows restart: {err}\x1b[0m");
+            log.error(&format!("failed to schedule Windows restart: {err}"));
             std::process::exit(1);
         }
 
@@ -62,7 +58,7 @@ pub(crate) fn re_exec(root: &std::path::Path) -> ! {
     {
         let args: Vec<String> = std::env::args().skip(1).collect();
         let exe = re_exec_path(root).unwrap_or_else(|err| {
-            eprintln!("\x1b[31mError: cannot determine executable path: {err}\x1b[0m");
+            log.error(&format!("cannot determine executable path: {err}"));
             std::process::exit(1);
         });
         match std::process::Command::new(&exe)
@@ -72,12 +68,12 @@ pub(crate) fn re_exec(root: &std::path::Path) -> ! {
         {
             Ok(s) => {
                 if s.code().is_none() {
-                    eprintln!("\x1b[33mWarning: child process terminated by signal\x1b[0m");
+                    log.warn("child process terminated by signal");
                 }
                 std::process::exit(s.code().unwrap_or(1))
             }
             Err(e) => {
-                eprintln!("\x1b[31mError: failed to re-exec: {e}\x1b[0m");
+                log.error(&format!("failed to re-exec: {e}"));
                 std::process::exit(1);
             }
         }

--- a/cli/src/commands/uninstall.rs
+++ b/cli/src/commands/uninstall.rs
@@ -24,7 +24,7 @@ pub fn run(
     if std::env::var_os(super::REEXEC_GUARD_VAR).is_none()
         && phases::bootstrap::self_update::pre_update(&root, &**log, global.dry_run)?
     {
-        super::re_exec(&root);
+        super::re_exec(&root, &**log);
     }
 
     let runner = super::CommandRunner::new(global, log, token)?;

--- a/cli/src/elevation.rs
+++ b/cli/src/elevation.rs
@@ -44,8 +44,10 @@ pub const fn is_elevated() -> bool {
 /// Returns an error if the user cancels the UAC prompt or the elevated
 /// process fails to start.
 #[cfg(windows)]
-#[allow(clippy::print_stderr, reason = "intentional user-facing output")]
-pub fn elevate_and_exit(executor: &dyn crate::exec::Executor) -> anyhow::Result<()> {
+pub fn elevate_and_exit(
+    executor: &dyn crate::exec::Executor,
+    log: &dyn crate::logging::Output,
+) -> anyhow::Result<()> {
     use anyhow::{Context, bail};
 
     let exe = std::env::current_exe().context("failed to determine current executable path")?;
@@ -65,7 +67,7 @@ pub fn elevate_and_exit(executor: &dyn crate::exec::Executor) -> anyhow::Result<
         "powershell"
     };
 
-    eprintln!("Not running as administrator. Requesting elevation...");
+    log.always("Not running as administrator. Requesting elevation...");
 
     let status = std::process::Command::new(ps_exe)
         .args([
@@ -77,7 +79,7 @@ pub fn elevate_and_exit(executor: &dyn crate::exec::Executor) -> anyhow::Result<
         .context("failed to start elevated process")?;
 
     if status.success() {
-        eprintln!("Elevated window opened.");
+        log.always("Elevated window opened.");
         std::process::exit(0);
     }
 

--- a/cli/src/engine/scheduler.rs
+++ b/cli/src/engine/scheduler.rs
@@ -43,8 +43,6 @@ fn run_task_guarded(task: &dyn Task, ctx: &Context, log: &Arc<Logger>) -> bool {
         return false;
     }
 
-    log.diag_task(DiagEvent::TaskDone, task.name(), "");
-
     buf.flush_and_complete(task.name());
     true
 }
@@ -137,27 +135,20 @@ pub(crate) fn run_tasks_parallel(tasks: &[&dyn Task], ctx: &Context, log: &Arc<L
                 let deps_ok = rx.is_none_or(|rx| (0..deps.len()).all(|_| rx.recv().is_ok()));
 
                 if !deps_ok {
+                    let reason = "dependency did not complete";
                     log.diag_task(
                         DiagEvent::TaskSkip,
                         task.name(),
-                        "skipped: dependency did not complete",
+                        &format!("skipped: {reason}"),
                     );
-                    log.record_task(
-                        task.name(),
-                        task.phase(),
-                        TaskStatus::Skipped,
-                        Some("dependency did not complete"),
-                    );
+                    log.record_task(task.name(), task.phase(), TaskStatus::Skipped, Some(reason));
+                    if !log.is_verbose() {
+                        log.emit_task_result(task.name(), &TaskStatus::Skipped, Some(reason));
+                    }
                     // my_senders is dropped here without sending, propagating
                     // RecvError to any tasks that depend on this one.
                     return;
                 }
-
-                log.diag_task(
-                    DiagEvent::TaskStart,
-                    task.name(),
-                    "deps satisfied, executing",
-                );
 
                 if run_task_guarded(task, ctx, log) {
                     // Signal all dependent tasks.

--- a/cli/src/exec.rs
+++ b/cli/src/exec.rs
@@ -50,11 +50,37 @@ fn execute_checked(mut cmd: Command, label: &str) -> Result<ExecResult> {
         .output()
         .with_context(|| format!("failed to execute: {label}"))?;
     let result = ExecResult::from(output);
+    log_command_output(label, &result);
     if !result.success {
         let code = result.code.unwrap_or(-1);
-        bail!("{label} failed (exit {code}): {}", result.stderr.trim());
+        bail!("{label} failed (exit {code}): {}", failure_output(&result));
     }
     Ok(result)
+}
+
+/// Log captured child-process output at debug level.
+fn log_command_output(label: &str, result: &ExecResult) {
+    log_stream(label, "stdout", &result.stdout);
+    log_stream(label, "stderr", &result.stderr);
+}
+
+/// Log one captured output stream line-by-line.
+fn log_stream(label: &str, stream: &str, output: &str) {
+    for line in output.lines().filter(|line| !line.trim().is_empty()) {
+        tracing::debug!(target: "dotfiles::exec", "{label} {stream}: {line}");
+    }
+}
+
+/// Format stdout/stderr for a failed command error message.
+fn failure_output(result: &ExecResult) -> String {
+    let stdout = result.stdout.trim();
+    let stderr = result.stderr.trim();
+    match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => "no output".to_string(),
+        (false, true) => format!("stdout: {stdout}"),
+        (true, false) => stderr.to_string(),
+        (false, false) => format!("stdout: {stdout}; stderr: {stderr}"),
+    }
 }
 
 /// Trait for executing system commands, enabling test injection.
@@ -170,7 +196,9 @@ impl Executor for SystemExecutor {
             .args(args)
             .output()
             .with_context(|| format!("failed to execute: {program}"))?;
-        Ok(ExecResult::from(output))
+        let result = ExecResult::from(output);
+        log_command_output(program, &result);
+        Ok(result)
     }
 
     fn run_unchecked_in(&self, dir: &Path, program: &str, args: &[&str]) -> Result<ExecResult> {
@@ -179,7 +207,9 @@ impl Executor for SystemExecutor {
             .current_dir(dir)
             .output()
             .with_context(|| format!("failed to execute: {program} in {}", dir.display()))?;
-        Ok(ExecResult::from(output))
+        let result = ExecResult::from(output);
+        log_command_output(&format!("{program} in {}", dir.display()), &result);
+        Ok(result)
     }
 
     fn which(&self, program: &str) -> bool {

--- a/cli/src/logging/diagnostic.rs
+++ b/cli/src/logging/diagnostic.rs
@@ -173,8 +173,7 @@ impl DiagnosticLog {
         }
     }
 
-    /// Return the path of the diagnostic log file (test-only).
-    #[cfg(test)]
+    /// Return the path of the diagnostic log file.
     pub(crate) fn path(&self) -> &std::path::Path {
         &self.path
     }

--- a/cli/src/logging/logger/summary.rs
+++ b/cli/src/logging/logger/summary.rs
@@ -111,6 +111,12 @@ impl Logger {
         if let Some(path) = &self.log_file {
             self.always(&format!("  \x1b[2mlog: {}\x1b[0m", path.display()));
         }
+        if let Some(diag) = &self.diagnostic {
+            self.always(&format!(
+                "  \x1b[2mdiagnostic log: {}\x1b[0m",
+                diag.path().display()
+            ));
+        }
     }
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,6 @@ use std::process::ExitCode;
 use clap::{CommandFactory, Parser};
 use dotfiles_cli::{cli, commands, engine, logging};
 
-#[allow(clippy::print_stderr, reason = "intentional user-facing output")]
 fn main() -> ExitCode {
     drop(enable_ansi_support::enable_ansi_support()); // best-effort; no-op on non-Windows
     let args = cli::Cli::parse();
@@ -17,6 +16,17 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    let command_name = match &args.command {
+        cli::Command::Install(_) => "install",
+        cli::Command::Uninstall(_) => "uninstall",
+        cli::Command::Test(_) => "test",
+        cli::Command::Version | cli::Command::Completions(_) => "version",
+    };
+    logging::init_subscriber(args.verbose, command_name);
+    let mut raw_log = logging::Logger::new(command_name);
+    raw_log.set_verbose(args.verbose);
+    let log = std::sync::Arc::new(raw_log);
+
     // Auto-elevate on Windows for install/uninstall when not in dry-run mode
     #[cfg(windows)]
     {
@@ -26,10 +36,12 @@ fn main() -> ExitCode {
         ) && !args.global.dry_run;
         if needs_elevation
             && !dotfiles_cli::elevation::is_elevated()
-            && let Err(e) =
-                dotfiles_cli::elevation::elevate_and_exit(&dotfiles_cli::exec::SystemExecutor)
+            && let Err(e) = dotfiles_cli::elevation::elevate_and_exit(
+                &dotfiles_cli::exec::SystemExecutor,
+                &*log,
+            )
         {
-            eprintln!("\x1b[31mError: {e}\x1b[0m");
+            log.error(&format!("{e:#}"));
             return ExitCode::FAILURE;
         }
     }
@@ -38,26 +50,16 @@ fn main() -> ExitCode {
     // finish cleanly instead of terminating the process immediately.
     let token = engine::CancellationToken::new();
     let handler_token = token.clone();
+    let handler_log = std::sync::Arc::clone(&log);
     if ctrlc::set_handler(move || {
         handler_token.cancel();
-        eprintln!("\x1b[33minterrupt received — finishing in-flight operations\x1b[0m");
+        handler_log.warn("interrupt received - finishing in-flight operations");
     })
     .is_err()
     {
         // Non-fatal: we just lose graceful shutdown support.
-        eprintln!("\x1b[33mWarning: failed to register signal handler\x1b[0m");
+        log.warn("failed to register signal handler");
     }
-
-    let command_name = match &args.command {
-        cli::Command::Install(_) => "install",
-        cli::Command::Uninstall(_) => "uninstall",
-        cli::Command::Test(_) => "test",
-        cli::Command::Version | cli::Command::Completions(_) => "version",
-    };
-    logging::init_subscriber(args.verbose, command_name);
-    let mut log = logging::Logger::new(command_name);
-    log.set_verbose(args.verbose);
-    let log = std::sync::Arc::new(log);
 
     let result = match args.command {
         cli::Command::Install(opts) => commands::install::run(&args.global, &opts, &log, &token),
@@ -75,7 +77,7 @@ fn main() -> ExitCode {
     };
 
     if let Err(e) = result {
-        eprintln!("\x1b[31mError: {e}\x1b[0m");
+        log.error(&format!("{e:#}"));
         dotfiles_cli::elevation::wait_if_elevated();
         return ExitCode::FAILURE;
     }

--- a/cli/src/phases/apply/pam.rs
+++ b/cli/src/phases/apply/pam.rs
@@ -31,6 +31,22 @@ impl ConfigurePam {
                 .active_categories
                 .contains(&Category::Desktop)
     }
+
+    /// Returns `true` when `service` needs a privileged PAM file update.
+    fn needs_sudo_for_service(ctx: &Context, service: &str) -> bool {
+        if ctx.dry_run {
+            return false;
+        }
+        if !Self::is_arch_desktop(ctx) {
+            return false;
+        }
+        // Only request sudo when the file actually needs changes.
+        let resource = PamConfigResource::new(service.to_string(), Arc::clone(&ctx.executor));
+        !matches!(
+            resource.current_state(),
+            Ok(crate::resources::ResourceState::Correct)
+        )
+    }
 }
 
 impl Task for ConfigurePam {
@@ -47,19 +63,7 @@ impl Task for ConfigurePam {
     }
 
     fn needs_sudo(&self, ctx: &Context) -> bool {
-        if ctx.dry_run {
-            return false;
-        }
-        if !Self::is_arch_desktop(ctx) {
-            return false;
-        }
-        // Only request sudo when the file actually needs changes.
-        let resource =
-            PamConfigResource::new(HYPRLOCK_SERVICE.to_string(), Arc::clone(&ctx.executor));
-        !matches!(
-            resource.current_state(),
-            Ok(crate::resources::ResourceState::Correct)
-        )
+        Self::needs_sudo_for_service(ctx, HYPRLOCK_SERVICE)
     }
 
     fn run(&self, ctx: &Context) -> Result<TaskResult> {
@@ -154,7 +158,10 @@ mod tests {
     #[test]
     fn needs_sudo_true_on_arch_desktop() {
         let ctx = make_arch_desktop_context();
-        assert!(ConfigurePam.needs_sudo(&ctx));
+        assert!(ConfigurePam::needs_sudo_for_service(
+            &ctx,
+            "dotfiles-test-nonexistent-service"
+        ));
     }
 
     #[test]

--- a/cli/src/phases/mod.rs
+++ b/cli/src/phases/mod.rs
@@ -41,7 +41,7 @@ use std::fmt;
 
 use anyhow::Result;
 
-use crate::logging::TaskStatus;
+use crate::logging::{DiagEvent, TaskStatus};
 
 /// Unique identifier for a task in the dependency graph.
 ///
@@ -206,6 +206,8 @@ pub fn execute(task: &dyn Task, ctx: &Context) {
     let phase = task.phase();
 
     if !task.should_run(ctx) {
+        ctx.log
+            .diag_task(DiagEvent::TaskSkip, task.name(), "not applicable");
         if ctx.log.debug_enabled() {
             ctx.log.stage(task.name());
         }
@@ -216,8 +218,12 @@ pub fn execute(task: &dyn Task, ctx: &Context) {
         return;
     }
 
+    ctx.log
+        .diag_task(DiagEvent::TaskStart, task.name(), "executing");
     match task.run_if_applicable(ctx) {
         Ok(None) => {
+            ctx.log
+                .diag_task(DiagEvent::TaskSkip, task.name(), "nothing configured");
             if ctx.log.debug_enabled() {
                 ctx.log.stage(task.name());
             }
@@ -226,18 +232,25 @@ pub fn execute(task: &dyn Task, ctx: &Context) {
                 .record_task(task.name(), phase, TaskStatus::NotApplicable, None);
         }
         Ok(Some(result)) => match result {
-            TaskResult::Ok => record(ctx, task.name(), phase, TaskStatus::Ok, None),
+            TaskResult::Ok => {
+                ctx.log.diag_task(DiagEvent::TaskDone, task.name(), "");
+                record(ctx, task.name(), phase, TaskStatus::Ok, None);
+            }
             TaskResult::NotApplicable(reason) => {
+                ctx.log.diag_task(DiagEvent::TaskSkip, task.name(), &reason);
                 ctx.debug_fmt(|| format!("not applicable: {reason}"));
                 ctx.log
                     .record_task(task.name(), phase, TaskStatus::NotApplicable, None);
             }
             TaskResult::Skipped(reason) => {
+                ctx.log.diag_task(DiagEvent::TaskSkip, task.name(), &reason);
                 ctx.log.info(&format!("skipped: {reason}"));
                 record(ctx, task.name(), phase, TaskStatus::Skipped, Some(&reason));
             }
             TaskResult::Failed(reason) => {
                 if ctx.is_cancelled() {
+                    ctx.log
+                        .diag_task(DiagEvent::TaskSkip, task.name(), "interrupted");
                     ctx.log.warn(&format!("interrupted: {reason}"));
                     record(
                         ctx,
@@ -247,14 +260,21 @@ pub fn execute(task: &dyn Task, ctx: &Context) {
                         Some("interrupted"),
                     );
                 } else {
+                    ctx.log.diag_task(DiagEvent::TaskFail, task.name(), &reason);
                     ctx.log.warn(&format!("failed: {reason}"));
                     record(ctx, task.name(), phase, TaskStatus::Failed, Some(&reason));
                 }
             }
-            TaskResult::DryRun => record(ctx, task.name(), phase, TaskStatus::DryRun, None),
+            TaskResult::DryRun => {
+                ctx.log
+                    .diag_task(DiagEvent::TaskDone, task.name(), "dry-run");
+                record(ctx, task.name(), phase, TaskStatus::DryRun, None);
+            }
         },
         Err(e) => {
             if ctx.is_cancelled() {
+                ctx.log
+                    .diag_task(DiagEvent::TaskSkip, task.name(), "interrupted");
                 ctx.log.warn(&format!("interrupted: {}", task.name()));
                 record(
                     ctx,
@@ -264,6 +284,8 @@ pub fn execute(task: &dyn Task, ctx: &Context) {
                     Some("interrupted"),
                 );
             } else {
+                ctx.log
+                    .diag_task(DiagEvent::TaskFail, task.name(), &format!("{e:#}"));
                 ctx.log.error(&format!("{}: {e:#}", task.name()));
                 record(
                     ctx,


### PR DESCRIPTION
## Summary

Fixes five observability/logging issues identified in audit:

### 1. Diagnostic log path shown in run summary
The high-precision `.diag.log` file path is now printed in the end-of-run summary alongside the main log path, making it discoverable without needing to know the `$XDG_CACHE_HOME` path.

### 2. Fatal errors captured in the log file
- Logger is initialized **before** elevation and Ctrl-C setup, so all startup warnings reach the log file
- Windows elevation status messages route through `log.always()`/`log.error()`
- Ctrl-C handler and signal registration failure use `log.warn()`
- Final command-error path in `main()` uses `log.error()`

### 3. Sequential tasks gain diagnostic lifecycle events
`phases::execute()` now emits `TaskStart`, `TaskDone`, `TaskSkip`, and `TaskFail` diagnostic events for every outcome, matching the coverage that the parallel scheduler already had. The `.diag.log` timeline is now consistent regardless of execution mode.

### 4. Parallel dependency skips are visible in non-verbose output
When a task is skipped because a dependency failed to complete, the scheduler now calls `emit_task_result()` in non-verbose mode so the user sees the skip inline rather than only in the summary totals.

### 5. Child process output captured in persistent log
`SystemExecutor` now logs every child process's stdout and stderr line-by-line at `debug` level via `tracing`. This means package manager, git, systemctl, and script output all appear in `install.log` / `uninstall.log` when verbose mode is on, and always in the `.diag.log`. Failure error messages also include stdout when stderr is absent.

### Bonus: PAM test made deterministic
The `needs_sudo_true_on_arch_desktop` test was probing the real `/etc/pam.d/hyprlock-custom` on the test host. Extracted a testable helper `needs_sudo_for_service(ctx, service)` and the test now uses a guaranteed-nonexistent service name.