### PR TITLE
Alias code to VS Code Insiders in PowerShell

### DIFF
--- a/symlinks/config/powershell/Microsoft.PowerShell_profile.ps1
+++ b/symlinks/config/powershell/Microsoft.PowerShell_profile.ps1
@@ -11,6 +11,11 @@ if (Get-Module PSReadLine)
 
 $Global:GitExists = [bool](Get-Command "git" -ErrorAction SilentlyContinue)
 
+if (Get-Command "code-insiders" -ErrorAction SilentlyContinue)
+{
+    Set-Alias -Name code -Value code-insiders
+}
+
 $Global:IsNestedPwsh = $false
 if ($null -eq $env:windir)
 {


### PR DESCRIPTION
## Summary
- Add a conditional PowerShell alias so `code` resolves to `code-insiders` when VS Code Insiders is installed
- Leave `code` unchanged when `code-insiders` is not available

## Validation
- Verified the profile parses successfully
- Verified `code` resolves to the alias and reports the same version as `code-insiders` after sourcing the updated profile